### PR TITLE
Option B: implement picker-based photo intake path

### DIFF
--- a/.github/workflows/ingest-photos.yml
+++ b/.github/workflows/ingest-photos.yml
@@ -1,4 +1,4 @@
-name: Ingest OIO Photos from Google Photos
+name: Ingest OIO Photos (Picker + Album Fallback)
 
 on:
   schedule:
@@ -30,15 +30,16 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: python scripts/ingest_photos.py
 
-      - name: Commit updated photo logs
+      - name: Commit updated photo logs and picker selections
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add photos/
+          git add intake/selected-photos.json
           if git diff --cached --quiet; then
-            echo "No new photos to log."
+            echo "No ingestion state changes to commit."
           else
-            git commit -m "chore: ingest new photos from Google Photos album [skip ci]"
+            git commit -m "chore: ingest selected/new photos [skip ci]"
             git push
-            echo "Photo logs updated and pushed."
+            echo "Ingestion updates pushed."
           fi

--- a/PHOTO-WORKFLOW.md
+++ b/PHOTO-WORKFLOW.md
@@ -1,16 +1,18 @@
 # OIO Racing Photo Workflow
 
-Automated pipeline from Google Photos album to PostBridge draft social posts,
+Automated pipeline from Google Photos picker/album intake to PostBridge draft social posts,
 with photo metadata tracked in the OIO brain.
 
 ## Architecture
 
 ```
-Google Photos Album
+Google Photos Picker (preferred) OR Google Photos Album (fallback)
         ↓
 [ingest-photos.yml — every 6h]
         ↓
 Google Photos Library API
+  → first process intake/selected-photos.json pending selections
+  → fallback to album polling if no pending selections
   → upload binary to Supabase oio-photos bucket (storage only, no DB)
   → Claude Vision (auto vehicle identification)
   → write entry to photos/{driver}/{vehicle-slug}/photo-log.md
@@ -40,6 +42,7 @@ Ian reviews draft in PostBridge → approves → publishes
 
 | Data | Location |
 |---|---|
+| Picker-selected intake queue | `intake/selected-photos.json` |
 | Binary photo files | Supabase Storage — `oio-photos` bucket |
 | Photo metadata and workflow state | `photos/{driver}/{vehicle-slug}/photo-log.md` |
 | Unidentified / triage photos | `photos/triage/photo-log.md` |
@@ -88,7 +91,7 @@ Each photo entry has a `workflow_status` field that tracks progress:
 | Script | Purpose |
 |---|---|
 | `scripts/photo_log.py` | Shared utility — reads and writes photo-log.md entries |
-| `scripts/ingest_photos.py` | Google Photos → Supabase Storage + photo-log.md |
+| `scripts/ingest_photos.py` | `selected-photos.json`/album → Supabase Storage + photo-log.md |
 | `scripts/generate_captions.py` | Caption generation via Claude + OIO brain context |
 | `scripts/create_postbridge_drafts.py` | PostBridge draft creation with Tue/Fri scheduling |
 | `scripts/postbridge_client.py` | PostBridge API client library |
@@ -98,7 +101,7 @@ Each photo entry has a `workflow_status` field that tracks progress:
 
 | Workflow | Schedule | Purpose |
 |---|---|---|
-| `ingest-photos.yml` | Every 6 hours | Detect new photos, upload to Supabase Storage, run Vision, write photo-log.md |
+| `ingest-photos.yml` | Every 6 hours | Process selected intake first, then fallback album polling, run Vision, write photo-log.md |
 | `generate-captions.yml` | Daily at 8:30 AM UTC | Generate captions, update photo-log.md |
 | `create-drafts.yml` | Daily at 9:00 AM UTC | Create PostBridge drafts, update photo-log.md |
 
@@ -140,7 +143,18 @@ python scripts/auth_google_photos.py
 
 Save the output JSON as the `GOOGLE_PHOTOS_CREDENTIALS` GitHub secret.
 
-### 3. Google Photos album
+### 3. Intake path
+
+Preferred:
+
+- Use `intake/web/` to prepare and commit `intake/selected-photos.json`.
+- The ingestion workflow consumes pending selected IDs and marks them ingested.
+
+Fallback:
+
+- Keep `GOOGLE_PHOTOS_ALBUM_ID` configured to use album polling when no pending selected items exist.
+
+### 4. Google Photos album
 
 Create a dedicated Google Photos album for OIO social posting.
 Copy the album ID from the URL and save it as `GOOGLE_PHOTOS_ALBUM_ID`.

--- a/intake/selected-photos.json
+++ b/intake/selected-photos.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "last_updated": null,
+  "sessions": []
+}

--- a/intake/web/README.md
+++ b/intake/web/README.md
@@ -1,0 +1,52 @@
+# OIO Picker Intake Web UI
+
+This directory provides a lightweight web UI to create and commit
+`intake/selected-photos.json` for the Option B intake path.
+
+## What it does
+
+- Accepts selected Google Photos media IDs (paste JSON from your picker response)
+- Builds a session payload using the repo schema
+- Lets you download `selected-photos.json` locally
+- Optionally commits `intake/selected-photos.json` to GitHub via API token
+
+## Run locally
+
+```bash
+cd intake/web
+python3 -m http.server 8000
+# open http://localhost:8000
+```
+
+## Input format
+
+Paste a JSON array of selected items in the UI:
+
+```json
+[
+  {
+    "id": "AMxabc123",
+    "filename": "IMG_1234.JPG",
+    "description": "RayRocks launch",
+    "baseUrl": "https://lh3.googleusercontent.com/...",
+    "creationTime": "2026-04-05T16:25:00Z"
+  }
+]
+```
+
+Only `id` is required.
+
+## Commit flow
+
+1. Set `owner/repo` (for example `spacecowboyian/oio-brain`)
+2. Set a GitHub token with repo write permissions
+3. Set branch (default `main`)
+4. Click **Commit to GitHub**
+
+The UI writes `intake/selected-photos.json` in the target branch.
+
+## Notes
+
+- This UI intentionally avoids build tooling to keep adoption simple.
+- Ingestion is handled by `scripts/ingest_photos.py`.
+- Marking items as processed happens during ingestion.

--- a/intake/web/index.html
+++ b/intake/web/index.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OIO Photo Intake Picker</title>
+    <style>
+      body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem; max-width: 980px; }
+      h1 { margin-bottom: 0.25rem; }
+      .muted { color: #555; }
+      .row { display: flex; gap: 0.5rem; flex-wrap: wrap; margin: 0.75rem 0; }
+      button { padding: 0.55rem 0.9rem; border-radius: 8px; border: 1px solid #bbb; background: #fafafa; cursor: pointer; }
+      textarea { width: 100%; min-height: 180px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .card { border: 1px solid #e0e0e0; border-radius: 12px; padding: 1rem; margin: 1rem 0; }
+      .ok { color: #0a7a35; }
+      .warn { color: #9c5d00; }
+      .error { color: #ad1a1a; }
+      code { background: #f5f5f5; padding: 0.12rem 0.3rem; border-radius: 4px; }
+    </style>
+  </head>
+  <body>
+    <h1>OIO Google Photos Intake</h1>
+    <p class="muted">
+      Option B intake path: capture explicit media selections and save them to
+      <code>intake/selected-photos.json</code>.
+    </p>
+
+    <div class="card">
+      <h2>1) Configure</h2>
+      <p class="muted">Set these once in the browser to enable save-to-GitHub from this page.</p>
+      <div class="row">
+        <button id="saveConfig">Save Config</button>
+        <button id="loadConfig">Load Config</button>
+      </div>
+      <label>GitHub owner/repo (example: <code>spacecowboyian/oio-brain</code>)</label>
+      <textarea id="repo" style="min-height: 42px"></textarea>
+      <label>GitHub token (repo scope)</label>
+      <textarea id="token" style="min-height: 70px"></textarea>
+      <label>Git branch for commit</label>
+      <textarea id="branch" style="min-height: 42px">main</textarea>
+      <div id="cfgStatus" class="muted"></div>
+    </div>
+
+    <div class="card">
+      <h2>2) Paste Selected Media JSON</h2>
+      <p class="muted">
+        Paste an array of media items from your Picker response. Minimum fields per item:
+        <code>id</code>, optional: <code>filename</code>, <code>description</code>, <code>baseUrl</code>, <code>creationTime</code>.
+      </p>
+      <textarea id="selectedJson" placeholder='[{"id":"AMx...","filename":"IMG_1234.JPG"}]'></textarea>
+      <div class="row">
+        <button id="previewBtn">Preview Session JSON</button>
+        <button id="downloadBtn">Download selected-photos.json</button>
+        <button id="commitBtn">Commit to GitHub</button>
+      </div>
+      <div id="runStatus" class="muted"></div>
+    </div>
+
+    <div class="card">
+      <h2>3) Generated Session Payload</h2>
+      <textarea id="outputJson"></textarea>
+    </div>
+
+    <script src="./picker.js"></script>
+  </body>
+</html>

--- a/intake/web/picker.js
+++ b/intake/web/picker.js
@@ -1,0 +1,169 @@
+(function () {
+  const repoEl = document.getElementById("repo");
+  const tokenEl = document.getElementById("token");
+  const branchEl = document.getElementById("branch");
+  const inputEl = document.getElementById("selectedJson");
+  const outputEl = document.getElementById("outputJson");
+  const cfgStatus = document.getElementById("cfgStatus");
+  const runStatus = document.getElementById("runStatus");
+
+  function setStatus(el, cls, text) {
+    el.className = cls;
+    el.textContent = text;
+  }
+
+  function nowIso() {
+    return new Date().toISOString();
+  }
+
+  function toSession(items) {
+    return {
+      session_id: crypto.randomUUID(),
+      created_at: nowIso(),
+      processed: false,
+      items: items.map((item) => ({
+        id: item.id,
+        filename: item.filename || `photo_${item.id}.jpg`,
+        description: item.description || null,
+        baseUrl: item.baseUrl || null,
+        creationTime: item.creationTime || null,
+        status: "selected",
+        processed_at: null,
+      })),
+    };
+  }
+
+  function parseInput() {
+    let parsed;
+    try {
+      parsed = JSON.parse(inputEl.value || "[]");
+    } catch (err) {
+      throw new Error(`Invalid JSON: ${err.message}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("Input must be a JSON array of selected media items.");
+    }
+    const valid = parsed.filter((x) => x && typeof x.id === "string" && x.id.length > 0);
+    if (!valid.length) {
+      throw new Error("No valid selected items found (expected objects with string id).");
+    }
+    return valid;
+  }
+
+  function buildSelectedPhotosDoc() {
+    const items = parseInput();
+    return {
+      schema_version: 1,
+      last_updated: nowIso(),
+      sessions: [toSession(items)],
+    };
+  }
+
+  function cfgKey() {
+    return "oio-picker-config";
+  }
+
+  document.getElementById("saveConfig").addEventListener("click", () => {
+    localStorage.setItem(
+      cfgKey(),
+      JSON.stringify({ repo: repoEl.value.trim(), token: tokenEl.value.trim(), branch: branchEl.value.trim() || "main" })
+    );
+    setStatus(cfgStatus, "ok", "Config saved locally.");
+  });
+
+  document.getElementById("loadConfig").addEventListener("click", () => {
+    const raw = localStorage.getItem(cfgKey());
+    if (!raw) {
+      setStatus(cfgStatus, "warn", "No saved config found.");
+      return;
+    }
+    const cfg = JSON.parse(raw);
+    repoEl.value = cfg.repo || "";
+    tokenEl.value = cfg.token || "";
+    branchEl.value = cfg.branch || "main";
+    setStatus(cfgStatus, "ok", "Config loaded.");
+  });
+
+  document.getElementById("previewBtn").addEventListener("click", () => {
+    try {
+      const doc = buildSelectedPhotosDoc();
+      outputEl.value = JSON.stringify(doc, null, 2);
+      setStatus(runStatus, "ok", `Prepared ${doc.sessions[0].items.length} selected item(s).`);
+    } catch (err) {
+      setStatus(runStatus, "error", err.message);
+    }
+  });
+
+  document.getElementById("downloadBtn").addEventListener("click", () => {
+    try {
+      const doc = buildSelectedPhotosDoc();
+      outputEl.value = JSON.stringify(doc, null, 2);
+      const blob = new Blob([`${JSON.stringify(doc, null, 2)}\n`], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "selected-photos.json";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      setStatus(runStatus, "ok", "Downloaded selected-photos.json.");
+    } catch (err) {
+      setStatus(runStatus, "error", err.message);
+    }
+  });
+
+  document.getElementById("commitBtn").addEventListener("click", async () => {
+    const repo = repoEl.value.trim();
+    const token = tokenEl.value.trim();
+    const branch = branchEl.value.trim() || "main";
+    if (!repo || !token) {
+      setStatus(runStatus, "error", "Repo and token are required for GitHub commit.");
+      return;
+    }
+
+    try {
+      const doc = buildSelectedPhotosDoc();
+      outputEl.value = JSON.stringify(doc, null, 2);
+      const [owner, repoName] = repo.split("/");
+      if (!owner || !repoName) {
+        throw new Error("Repo must be in owner/repo format.");
+      }
+
+      const path = "intake/selected-photos.json";
+      const base = `https://api.github.com/repos/${owner}/${repoName}/contents/${path}`;
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      };
+
+      const getResp = await fetch(`${base}?ref=${encodeURIComponent(branch)}`, { headers });
+      let sha = undefined;
+      if (getResp.status === 200) {
+        const body = await getResp.json();
+        sha = body.sha;
+      } else if (getResp.status !== 404) {
+        const text = await getResp.text();
+        throw new Error(`GitHub read failed (${getResp.status}): ${text}`);
+      }
+
+      const commitBody = {
+        message: "chore(intake): add picker-selected photos",
+        content: btoa(unescape(encodeURIComponent(`${JSON.stringify(doc, null, 2)}\n`))),
+        branch,
+        sha,
+      };
+
+      const putResp = await fetch(base, { method: "PUT", headers, body: JSON.stringify(commitBody) });
+      if (!putResp.ok) {
+        const text = await putResp.text();
+        throw new Error(`GitHub commit failed (${putResp.status}): ${text}`);
+      }
+      const result = await putResp.json();
+      setStatus(runStatus, "ok", `Committed selected photos: ${result.commit.sha.slice(0, 7)} on ${branch}`);
+    } catch (err) {
+      setStatus(runStatus, "error", err.message);
+    }
+  });
+})();

--- a/scripts/ingest_photos.py
+++ b/scripts/ingest_photos.py
@@ -47,6 +47,7 @@ import photo_log as pl
 
 REPO_ROOT = Path(__file__).parent.parent
 AUTO_IDENTIFY_THRESHOLD = 0.8
+SELECTED_PHOTOS_PATH = REPO_ROOT / "intake" / "selected-photos.json"
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +119,13 @@ def fetch_album_photos(creds: Credentials) -> list:
             resp.raise_for_status()
         except requests.RequestException as exc:
             log(f"Failed to fetch album photos: {exc}", "ERROR")
+            # 403 indicates a policy/access constraint, not an empty album.
+            if getattr(exc.response, "status_code", None) == 403:
+                raise RuntimeError(
+                    "Google Photos album search returned 403. "
+                    "Use Picker-based intake (intake/selected-photos.json) "
+                    "or update access policy."
+                ) from exc
             return items
 
         data = resp.json()
@@ -139,6 +147,80 @@ def download_photo(base_url: str) -> bytes | None:
     except requests.RequestException as exc:
         log(f"Failed to download photo: {exc}", "ERROR")
         return None
+
+
+def load_selected_photos() -> list[dict]:
+    """
+    Load pending selected photo items from intake/selected-photos.json.
+    """
+    if not SELECTED_PHOTOS_PATH.exists():
+        return []
+
+    try:
+        data = json.loads(SELECTED_PHOTOS_PATH.read_text())
+    except Exception as exc:
+        log(f"Failed to read {SELECTED_PHOTOS_PATH}: {exc}", "ERROR")
+        return []
+
+    sessions = data.get("sessions", [])
+    pending: list[dict] = []
+    for session in sessions:
+        for item in session.get("items", []):
+            if item.get("status") == "ingested" or item.get("processed_at"):
+                continue
+            if item.get("id"):
+                pending.append(item)
+
+    log(f"Loaded {len(pending)} pending selected photos from intake/selected-photos.json")
+    return pending
+
+
+def fetch_media_item_by_id(creds: Credentials, media_id: str) -> dict | None:
+    """
+    Fetch a single media item from Google Photos by media item id.
+    """
+    url = f"https://photoslibrary.googleapis.com/v1/mediaItems/{media_id}"
+    headers = {"Authorization": f"Bearer {creds.token}"}
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        log(f"Failed to fetch selected media item {media_id}: {exc}", "ERROR")
+        return None
+
+
+def mark_selected_photos_processed(processed_ids: set[str]) -> None:
+    """
+    Mark selected photo items as ingested after successful processing.
+    """
+    if not processed_ids or not SELECTED_PHOTOS_PATH.exists():
+        return
+
+    try:
+        data = json.loads(SELECTED_PHOTOS_PATH.read_text())
+    except Exception as exc:
+        log(f"Failed to update {SELECTED_PHOTOS_PATH}: {exc}", "ERROR")
+        return
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    updated = 0
+    for session in data.get("sessions", []):
+        for item in session.get("items", []):
+            item_id = item.get("id")
+            if item_id in processed_ids:
+                item["status"] = "ingested"
+                item["processed_at"] = now
+                updated += 1
+        session_items = session.get("items", [])
+        if session_items and all(
+            i.get("status") == "ingested" or i.get("processed_at") for i in session_items
+        ):
+            session["processed"] = True
+
+    data["last_updated"] = now
+    SELECTED_PHOTOS_PATH.write_text(json.dumps(data, indent=2) + "\n")
+    log(f"Marked {updated} selected photos as ingested in intake/selected-photos.json")
 
 
 # ---------------------------------------------------------------------------
@@ -303,6 +385,7 @@ def ingest(media_items: list) -> dict:
     new_count = 0
     skip_count = 0
     error_count = 0
+    processed_ids: set[str] = set()
 
     for item in media_items:
         photo_id = item.get("id")
@@ -390,10 +473,12 @@ def ingest(media_items: list) -> dict:
 
         pl.append_entry(log_path, entry)
         known_ids.add(photo_id)
+        processed_ids.add(photo_id)
         new_count += 1
         log(f"[LOGGED] {filename} → {log_path.relative_to(REPO_ROOT)} ({workflow_status})")
 
     log(f"Ingestion complete: {new_count} new, {skip_count} skipped, {error_count} errors")
+    mark_selected_photos_processed(processed_ids)
     return {"new": new_count, "skipped": skip_count, "errors": error_count}
 
 
@@ -431,11 +516,23 @@ def main() -> None:
     log("=== OIO Racing Photo Ingestion ===")
 
     creds = load_credentials()
-    media_items = fetch_album_photos(creds)
+    selected_items = load_selected_photos()
 
-    if not media_items:
-        log("No photos found in album")
-        return
+    media_items: list[dict] = []
+    if selected_items:
+        for selected in selected_items:
+            media = fetch_media_item_by_id(creds, selected["id"])
+            if media:
+                # Preserve any custom description captured during picker selection.
+                if selected.get("description"):
+                    media["description"] = selected["description"]
+                media_items.append(media)
+        log(f"Using {len(media_items)} selected photos for ingestion")
+    else:
+        media_items = fetch_album_photos(creds)
+        if not media_items:
+            log("No photos found from selected-photos.json or album polling")
+            return
 
     ingest(media_items)
     log("=== Ingestion Complete ===")


### PR DESCRIPTION
## Summary
Implements the missing OUT-295 Option B artifacts directly in the repo with a verifiable branch and commit.

## Changes
- Add intake queue file: `intake/selected-photos.json`
- Add lightweight intake UI: `intake/web/index.html`, `intake/web/picker.js`, `intake/web/README.md`
- Update `scripts/ingest_photos.py` to:
  - prioritize selected-item ingestion from `selected-photos.json`
  - fetch selected media by id
  - mark processed items in `selected-photos.json`
  - fail fast on 403 album search errors
  - fallback to album polling when no selected items are pending
- Update workflow commit step to include `intake/selected-photos.json`
- Update workflow docs in `PHOTO-WORKFLOW.md`

## Validation
- `python3 -m py_compile scripts/ingest_photos.py`

## Ticket
- OUT-295
- OUT-297
